### PR TITLE
Add fallback quota logic for backward compatibility

### DIFF
--- a/src/controllers/aciControllers/exportLeads.ts
+++ b/src/controllers/aciControllers/exportLeads.ts
@@ -129,6 +129,38 @@ export async function checkAndDecrementQuotaAtomic(organizationId: string, count
 
         if (!quota) {
             logger.warn(`Quota not configured for organization ${organizationId} in period ${currentMonthYear}`);
+            // Fallback: Check if ANY quota exists for this org (for backward compatibility)
+            const anyQuota = await MonthlyQuotas.findOne({
+                where: { organization_id: organizationId },
+                order: [['startDate', 'DESC']],
+            });
+
+            if (anyQuota) {
+                logger.info(`Found quota for different period: ${anyQuota.startDate}. Using that instead.`);
+                // Use the most recent quota if current month doesn't exist
+                if (anyQuota.remaining < count) {
+                    logger.warn(`Quota exceeded for org ${organizationId}: remaining=${anyQuota.remaining}, requested=${count}`);
+                    return { ok: false, message: "Quota exceeded", remaining: anyQuota.remaining };
+                }
+
+                const result = await MonthlyQuotas.decrement('remaining', {
+                    by: count,
+                    where: { organization_id: organizationId, startDate: anyQuota.startDate }
+                }) as any;
+
+                const affectedRows = Array.isArray(result) ? result : result?.[0];
+                if (!affectedRows || affectedRows.length === 0) {
+                    logger.error(`Failed to decrement quota for org ${organizationId}`);
+                    return { ok: false, message: "Failed to update quota", remaining: anyQuota.remaining };
+                }
+
+                const updatedQuota = await MonthlyQuotas.findOne({
+                    where: { organization_id: organizationId, startDate: anyQuota.startDate }
+                });
+
+                return { ok: true, remaining: updatedQuota?.remaining ?? 0 };
+            }
+
             return { ok: false, message: "Export quota not configured for your organization", remaining: null };
         }
 


### PR DESCRIPTION
Issue: 500 error when current month quota doesn't exist

Fix:
- Check for current month quota first (primary)
- If not found, fallback to most recent quota (secondary)
- Prevents errors when quota records haven't been created for current month
- Better error handling with detailed logging
- Maintains backward compatibility

Scenario handling:
1. June quota exists: Use June quota
2. June quota missing but May exists: Use May quota (fallback)
3. No quota at all: Return clear error message

This gracefully handles:
✅ New month transitions
✅ Missing monthly quota records
✅ Quota lookups for organizations
✅ Better logging for debugging