### PR TITLE
Fix export to search both ACILeads and GeneralLeads tables

### DIFF
--- a/src/controllers/aciControllers/exportLeads.ts
+++ b/src/controllers/aciControllers/exportLeads.ts
@@ -4,6 +4,7 @@ import Users from "../../models/Users";
 import sendResponse from "../../utils/http/sendResponse";
 import MonthlyQuotas from "../../models/MonthlyQuotas";
 import {ACILeads} from "../../models/ACILeads";
+import { GeneralLeads } from "../../models/GeneralLeads";
 import {Op} from "sequelize";
 import {v4 as uuidv4} from "uuid";
 import {Parser} from "json2csv";
@@ -237,10 +238,10 @@ export async function generateExportCsv(
         logger.info(`Generating CSV for export ${exportId}: ${leadIds.length} leads`);
 
         // Issue #7: Verify leads exist and belong to organization
-        const rows = await ACILeads.findAll({
+        // Try ACILeads first (ACI-specific leads)
+        let aciRows = await ACILeads.findAll({
             where: {
                 id: { [Op.in]: leadIds },
-                // Add organization boundary check
                 organization_id: organizationId
             },
             include: [
@@ -251,23 +252,45 @@ export async function generateExportCsv(
             ]
         });
 
-        logger.info(`Found ${rows.length} leads matching export criteria (requested: ${leadIds.length})`);
+        logger.info(`Found ${aciRows.length} leads in ACILeads (requested: ${leadIds.length})`);
+
+        // If not all leads found in ACILeads, try GeneralLeads (org-wide cache)
+        let allRows: any[] = aciRows;
+        if (aciRows.length < leadIds.length) {
+            logger.info(`Searching for remaining leads in GeneralLeads cache`);
+            const foundInACI = aciRows.map(r => r.id);
+            const missingIds = leadIds.filter(id => !foundInACI.includes(id));
+
+            const generalRows = await GeneralLeads.findAll({
+                where: {
+                    id: { [Op.in]: missingIds },
+                    organization_id: organizationId
+                }
+            });
+
+            logger.info(`Found ${generalRows.length} additional leads in GeneralLeads`);
+
+            // Combine results from both tables
+            allRows = [...aciRows, ...generalRows];
+        }
+
+        logger.info(`Found ${allRows.length} leads total matching export criteria (requested: ${leadIds.length})`);
 
         // Issue #7: Check if all requested leads were found
-        if (rows.length === 0) {
-            logger.warn(`No leads found for export ${exportId} in org ${organizationId}`);
+        if (allRows.length === 0) {
+            logger.warn(`No leads found for export ${exportId} in org ${organizationId} (checked both ACILeads and GeneralLeads)`);
             throw new Error("No leads found with provided IDs in your organization");
         }
 
-        if (rows.length !== leadIds.length) {
-            const foundIds = rows.map(r => r.id);
+        if (allRows.length !== leadIds.length) {
+            const foundIds = allRows.map(r => r.id);
             const notFoundIds = leadIds.filter(id => !foundIds.includes(id));
             logger.warn(`${notFoundIds.length} leads not found or not accessible for export ${exportId}`);
             throw new Error(`${notFoundIds.length} leads not found or not accessible to your organization`);
         }
 
         // Process and normalize leads
-        const leads = rows.map((lead) =>
+        const leads = allRows.map((lead) =>
             normalizeLead(lead.get({ plain: true }) as PlainLead)
         );
 


### PR DESCRIPTION
Issue: Export failed with 'No leads found' because leads might be in GeneralLeads (org-wide cache) instead of just ACILeads

Solution:
- Try ACILeads first (ACI-specific leads)
- If not all found, fallback to GeneralLeads (org-wide cache)
- Combine results from both tables
- Check both sources in logging

This ensures:
✅ Leads from both sources can be exported
✅ Graceful fallback if using different lead source ✅ Better logging showing which tables were searched ✅ Backwards compatible with existing queries

The leads table used depends on the source:
- ACI-specific leads: stored in ACILeads
- General/cached leads: stored in GeneralLeads